### PR TITLE
feat(issue-2): Add DELETE support for the existing REST endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module go-restapi-server
+
+go 1.25.3
+
+require github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/main.go
+++ b/main.go
@@ -43,24 +43,6 @@ func CreatePersonEndpoint(w http.ResponseWriter, req *http.Request) {
 	json.NewEncoder(w).Encode(people)
 }
 func UpdatePersonEndpoint(w http.ResponseWriter, req *http.Request) {
-	// params := mux.Vars(req)
-	// for index, item := range people {
-	// 	if item.ID == params["id"] {
-	// 		people = append(people[:index], people[index+1:]...)
-	// 		break
-	// 	}
-	// }
-	// json.NewEncoder(w).Encode(people)
-
-	// var person Person
-	// _ = json.NewDecoder(req.Body).Decode(&person)
-	// person.ID = params["id"]
-	// people = append(people, person)
-	// json.NewEncoder(w).Encode(people)
-	DeletePersonEndpoint(w, req)
-	CreatePersonEndpoint(w, req)
-}
-func DeletePersonEndpoint(w http.ResponseWriter, req *http.Request) {
 	params := mux.Vars(req)
 	for index, item := range people {
 		if item.ID == params["id"] {
@@ -68,7 +50,24 @@ func DeletePersonEndpoint(w http.ResponseWriter, req *http.Request) {
 			break
 		}
 	}
+	var person Person
+	_ = json.NewDecoder(req.Body).Decode(&person)
+	person.ID = params["id"]
+	people = append(people, person)
 	json.NewEncoder(w).Encode(people)
+}
+func DeletePersonEndpoint(w http.ResponseWriter, req *http.Request) {
+	params := mux.Vars(req)
+	for index, item := range people {
+		if item.ID == params["id"] {
+			people = append(people[:index], people[index+1:]...)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"message":"Person deleted successfully"}`))
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+	w.Write([]byte(`{"error":"Person not found"}`))
 }
 func main() {
 	router := mux.NewRouter()

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// Helper function to reset people slice to initial state
+func resetPeople() {
+	people = nil
+	people = append(people, Person{ID: "1", Firstname: "Ernest", Lastname: "Hemingway", Address: &Address{City: "Dublin", State: "CA"}})
+	people = append(people, Person{ID: "2", Firstname: "George", Lastname: "Orwell"})
+}
+
+func TestDeletePersonEndpoint(t *testing.T) {
+	// Reset the people slice to initial state for each test
+	resetPeople()
+
+	// Test delete existing person
+	t.Run("delete existing person", func(t *testing.T) {
+		resetPeople() // Reset for each test case
+		req := httptest.NewRequest("DELETE", "/people/1", nil)
+		req = mux.SetURLVars(req, map[string]string{"id": "1"})
+		w := httptest.NewRecorder()
+		DeletePersonEndpoint(w, req)
+
+		if status := w.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+
+		// Check that we got the correct success message
+		expectedBody := `{"message":"Person deleted successfully"}`
+		body := w.Body.String()
+		if body != expectedBody {
+			t.Errorf("handler returned unexpected body: got %v want %v",
+				body, expectedBody)
+		}
+	})
+
+	// Test delete non-existing person
+	t.Run("delete non-existing person", func(t *testing.T) {
+		resetPeople() // Reset for each test case
+		req := httptest.NewRequest("DELETE", "/people/999", nil)
+		req = mux.SetURLVars(req, map[string]string{"id": "999"})
+		w := httptest.NewRecorder()
+		DeletePersonEndpoint(w, req)
+
+		if status := w.Code; status != http.StatusNotFound {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusNotFound)
+		}
+
+		// Check that we got the correct error message
+		expectedBody := `{"error":"Person not found"}`
+		body := w.Body.String()
+		if body != expectedBody {
+			t.Errorf("handler returned unexpected body: got %v want %v",
+				body, expectedBody)
+		}
+	})
+}
+
+func TestGetPersonEndpoint(t *testing.T) {
+	// Test that GET still works
+	resetPeople()
+	req := httptest.NewRequest("GET", "/people/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "1"})
+	w := httptest.NewRecorder()
+	GetPersonEndpoint(w, req)
+
+	if status := w.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}
+
+func TestGetPeopleEndpoint(t *testing.T) {
+	// Test that GET all still works
+	resetPeople()
+	req := httptest.NewRequest("GET", "/people", nil)
+	w := httptest.NewRecorder()
+	GetPeopleEndpoint(w, req)
+
+	if status := w.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #2
Add DELETE support for the existing REST endpoint

## Changes Made
- Branch: `auto/issue-2-add-delete-support-for-the-existing-rest`
- Commit: `3eff24e`

## Validation
- Workflow status: `success`

## Run Info
- Run dir: `none`